### PR TITLE
Update Tiled extension directory path for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When you want to add these plugins to your Tiled installation:
   Tiled extension directory is:
 
   - **Windows**
-   `C:/Users/<USER>/AppData/Local/Tiled/extensions/`
+   `C:/Users/%USERNAME%/AppData/Local/Tiled/extensions/`
   - **macOS**
   `~/Library/Preferences/Tiled/extensions/`
   - **Linux**


### PR DESCRIPTION
Instead of having this path string for windows.```C:/Users/<USER>/AppData/Local/Tiled/extensions/```. We can instead use ```C:/Users/%USERNAME%/AppData/Local/Tiled/extensions/``` which when pasted into a explorer window will automatically replace the ```<USER>``` with the currently logged in windows account name.