### PR TITLE
Get meta for Area2D objects from the object itself instead of the layer

### DIFF
--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -181,7 +181,7 @@ class GodotTilemapExporter {
                                 collision_mask: object.property("collision_mask")
                             }
                         ),
-                        this.meta_properties(layer.properties())
+                        this.meta_properties(object.properties())
                     );
 
                     const shapeId = this.addSubResource("RectangleShape2D", {
@@ -200,7 +200,7 @@ class GodotTilemapExporter {
                                 position: `Vector2( ${objectPositionX}, ${objectPositionY} )`,
                             }
                         ),
-                        this.meta_properties(layer.properties())
+                        {}
                     );
                 } else if (object.type == "Node2D") {
                     this.tileMapsString += stringifyNode(


### PR DESCRIPTION
At the moment, export of meta for Area2D objects is broken, see #42 

This PR fixes the problem by exporting the objects's meta instead of the layer's meta.

It also disables setting meta on the child CollisionShape2D, since there's no clear way to decide what should go in there.
Maybe anything with a prefix like `godot:child:meta:` could go in there, but it did not seem right, so I left it out of the PR for now.