### PR TITLE
Revert breaking changes to projectRoot and automatically determine projectRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,30 @@ If you prefer watching check the video in YouTube:
 
 [How to export from Tiled To Godot 3.2](https://youtu.be/4jSFAXIa_Lo)
 
+The exporter needs to know how to set resource paths correctly for Godot before exporting. There are several ways to do this:
+
+- If your Tiled files exist in your Godot project structure alongside the exported files, the exporter can automatically determine the resource paths. There is also the option to use the `projectRoot` custom property if needed.
+- If your Tiled files exist outside your Godot project structure, you will need to set the `relativePath` custom property so the exporter can determine resource paths.
+
+**_!!! Pay attention to the "/" instead of standard windows "\\". Single Backslash "\\" is used for escaping special symbols._**
+
+### Setting relativePath
+
+The custom property `relativePath : string` contains the relative path to the exported files from the Godot project root.
+The value of `relativePath` is transformed to a resource path which Godot uses.
+
+* When placed on a Tiled TileMap (.tmx) object, it will define where the Tileset objects (.tres) are located in the exported TileMap (.tscn).
+* When placed on a Tiled TileSet (.tsx) object, it will define where the Image is located in the exported TileMap (.tres).
+
+Example:
+If the location of an exported tileset is: `C:/project/maps/level1/tileset.tres`
+Then the `relativePath` custom property would be: `/maps/level1`
+
 ### Setting projectRoot `res://`
 
 The exporter needs to know where `res://` is so when you export to a subfolder in your Godot project all the relative paths for the resources `(res://)` are set correctly and relative to the project root. `res://` is equivalent to the location of `project.godot` in your Godot project.
 
-**By default, the exporter expects the Tiled files to be saved in a subfolder of your Godot project and will determine the project root automatically. Setting `projectRoot` is no longer required.**
+**By default, the exporter expects the Tiled files to be saved in a subfolder of your Godot project next to the exported files and will determine the project root automatically. Setting `projectRoot` is no longer required in this scenario.**
 
 If needed, you can override this path with a custom property `projectRoot : string` that is either relative to the file you are exporting (starting with a `.`) or an absolute path.
 Either way, the value of `projectRoot` is transformed to the `res://` resource path which Godot uses and should be equivalent to the location of `project.godot`.
@@ -69,8 +88,11 @@ Either way, the value of `projectRoot` is transformed to the `res://` resource p
 * When placed on a Tiled TileMap (.tmx) object it will be used as the root to determine the relative resource path to the Tileset objects (.tres) used in the exported TileMap (.tscn).
 * When placed on a Tiled TileSet (.tsx) object it will be used as the root to determine the relative resource path to the Image used in the exported TileMap (.tres).
 
-**_!!! Pay attention to the "/" instead of standard windows "\\".
-Single Backslash "\\" is used for escaping special symbols._**
+Example:
+If the location of an exported tileset is: `C:/project/maps/level1/tileset.tres`
+Then the `projectRoot` custom property would be: `C:/project`
+
+### Exporting to Godot
 
 If everything is fine when you go to _File -> Export As_, a new option should exist:
 

--- a/README.md
+++ b/README.md
@@ -59,19 +59,18 @@ If you prefer watching check the video in YouTube:
 
 ### Setting projectRoot `res://`
 
-The exporter needs to know where `res://` is. By default, it's in the same directory where the Tiled files are being saved.
-You can override this path with a custom property `projectRoot : string` that is either relative to the file you are exporting (starting with a `.`), or absolute path,
-Either way the value of projectRoot is transformed to a resource path which Godot use.
+The exporter needs to know where `res://` is so when you export to a subfolder in your Godot project all the relative paths for the resources `(res://)` are set correctly and relative to the project root. `res://` is equivalent to the location of `project.godot` in your Godot project.
 
-* When placed on a Tiled TileMap (.tmx) object it will define where the Tileset objects (.tres) are located in the exported TileMap (.tscn).
-* When placed on a Tiled TileSet (.tsx) object it will define where the Image is located in the exported TileMap (.tres).
+**By default, the exporter expects the Tiled files to be saved in a subfolder of your Godot project and will determine the project root automatically. Setting `projectRoot` is no longer required.**
+
+If needed, you can override this path with a custom property `projectRoot : string` that is either relative to the file you are exporting (starting with a `.`) or an absolute path.
+Either way, the value of `projectRoot` is transformed to the `res://` resource path which Godot uses and should be equivalent to the location of `project.godot`.
+
+* When placed on a Tiled TileMap (.tmx) object it will be used as the root to determine the relative resource path to the Tileset objects (.tres) used in the exported TileMap (.tscn).
+* When placed on a Tiled TileSet (.tsx) object it will be used as the root to determine the relative resource path to the Image used in the exported TileMap (.tres).
 
 **_!!! Pay attention to the "/" instead of standard windows "\\".
 Single Backslash "\\" is used for escaping special symbols._**
-
-This is needed so when you export to a subfolder in your Godot project all the relative
-paths for the resources `(res://)` are set correctly and relative to the custom property
-you've added `"projectRoot"`;
 
 If everything is fine when you go to _File -> Export As_, a new option should exist:
 

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -5,8 +5,6 @@ class GodotTilemapExporter {
     constructor(map, fileName) {
         this.map = map;
         this.fileName = fileName;
-        // noinspection JSUnresolvedFunction
-        this.projectRoot = getResPath(this.map.property("projectRoot"), fileName);
         this.tileOffset = 65536;
         this.tileMapsString = "";
         this.tilesetsString = "";
@@ -76,8 +74,8 @@ class GodotTilemapExporter {
             const tileset = this.map.tilesets[index];
             this.extResourceId = index + 1;
             this.tilesetsIndex.set(tileset.name, this.extResourceId);
-            // noinspection JSUnresolvedVariable
-            let tilesetPath = tileset.asset.fileName.replace(this.projectRoot, "").replace('.tsx', '.tres');
+            // noinspection JSUnresolvedFunction
+            let tilesetPath = getResPath(this.map.property("projectRoot"), this.map.property("relativePath"), tileset.asset.fileName.replace('.tsx', '.tres'));
             this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "TileSet");
         }
 
@@ -132,7 +130,8 @@ class GodotTilemapExporter {
                         this.extResourceId = this.extResourceId + 1;
                         textureResourceId = this.extResourceId;
                         this.tilesetsIndex.set(tilesetsIndexKey, this.extResourceId);
-                        let tilesetPath = object.tile.tileset.image.replace(this.projectRoot, "");
+                        // noinspection JSUnresolvedFunction
+                        let tilesetPath = getResPath(this.map.property("projectRoot"), this.map.property("relativePath"), object.tile.tileset.image);
                         this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "Texture");
                     } else {
                         textureResourceId = this.tilesetsIndex.get(tilesetsIndexKey);

--- a/export_to_godot_tilemap.js
+++ b/export_to_godot_tilemap.js
@@ -5,6 +5,8 @@ class GodotTilemapExporter {
     constructor(map, fileName) {
         this.map = map;
         this.fileName = fileName;
+        // noinspection JSUnresolvedFunction
+        this.projectRoot = getResPath(this.map.property("projectRoot"), fileName);
         this.tileOffset = 65536;
         this.tileMapsString = "";
         this.tilesetsString = "";
@@ -75,9 +77,8 @@ class GodotTilemapExporter {
             this.extResourceId = index + 1;
             this.tilesetsIndex.set(tileset.name, this.extResourceId);
             // noinspection JSUnresolvedVariable
-            let tilesetPath = getResPath(this.map.property("projectRoot"), tileset.asset.fileName);
-            let tilesetName = FileInfo.fileName(tileset.asset.fileName).replace('.tsx', '.tres');
-            this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, FileInfo.joinPaths(tilesetPath, tilesetName), "TileSet");
+            let tilesetPath = tileset.asset.fileName.replace(this.projectRoot, "").replace('.tsx', '.tres');
+            this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "TileSet");
         }
 
     }
@@ -131,9 +132,8 @@ class GodotTilemapExporter {
                         this.extResourceId = this.extResourceId + 1;
                         textureResourceId = this.extResourceId;
                         this.tilesetsIndex.set(tilesetsIndexKey, this.extResourceId);
-                        let tileImagePath = getResPath(this.map.property("projectRoot"), object.tile.tileset.image);
-                        let tileImageName = FileInfo.fileName(object.tile.tileset.image);
-                        this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, FileInfo.joinPaths(tileImagePath, tileImageName), "Texture");
+                        let tilesetPath = object.tile.tileset.image.replace(this.projectRoot, "");
+                        this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "Texture");
                     } else {
                         textureResourceId = this.tilesetsIndex.get(tilesetsIndexKey);
                     }

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -6,11 +6,7 @@ class GodotTilesetExporter {
         this.tileset = tileset;
         this.fileName = fileName;
         // noinspection JSUnresolvedFunction
-        this.projectRoot = getResPath(this.tileset.property("projectRoot"), fileName);
-        this.spriteImagePath = this.tileset.image.replace(this.projectRoot, "");
-        
-        // Strip leading slashes to prevent invalid triple slashes in Godot res:// path:
-        this.spriteImagePath = this.spriteImagePath.replace(/^\/+/, '');
+        this.spriteImagePath = getResPath(this.tileset.property("projectRoot"), this.tileset.property("relativePath"), this.tileset.image);
         this.shapesResources = "";
         this.shapes = "";
         this.navpolyMap = [];

--- a/export_to_godot_tileset.js
+++ b/export_to_godot_tileset.js
@@ -6,8 +6,8 @@ class GodotTilesetExporter {
         this.tileset = tileset;
         this.fileName = fileName;
         // noinspection JSUnresolvedFunction
-        this.imagePath = getResPath(this.tileset.property("projectRoot"), this.tileset.image);
-        this.spriteImagePath = FileInfo.joinPaths(this.imagePath, FileInfo.fileName(this.tileset.image));
+        this.projectRoot = getResPath(this.tileset.property("projectRoot"), fileName);
+        this.spriteImagePath = this.tileset.image.replace(this.projectRoot, "");
         
         // Strip leading slashes to prevent invalid triple slashes in Godot res:// path:
         this.spriteImagePath = this.spriteImagePath.replace(/^\/+/, '');

--- a/utils.js
+++ b/utils.js
@@ -10,24 +10,47 @@ function logk(data) {
   console.log(Object.keys(data));
 }
 
+/**
+ * Determines the project root of a Godot project, which is the equivalent of 'res://' within Godot.
+ * There are three possible inputs for projectRoot:
+ * - absolute: This defines the projectRoot. Ex: getResPath('C:/project', 'C:/project/map/tileset.tres') => 'C:/project'
+ * - relative: This defines the projectRoot relative to the outputPath. Ex: getResPath('./..', 'C:/project/map/tileset.tres') => 'C:/project'
+ * - undefined: Attempts to automatically determine the projectRoot. Ex: getResPath(undefined, 'C:/project/map/tileset.tres') => 'C:/project'
+ * Information on file paths in Godot: https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html
+ *
+ * @param {string} projectRoot desired project root path, which can be an absolute or relative path
+ * @param {string} outputPath full path and name of destination file
+ * @return {string} project root path, which is the equivalent of 'res://'
+ */
 function getResPath(projectRoot, outputPath) {
   const p = outputPath.split('/').slice(0, -1)
-  // check for projectRoot
-  // If projectRoot is not set, set it to current file's location
+
+  // If projectRoot is not set, attempt to automatically determine projectRoot by searching for godot project file
   if (!projectRoot) {
-    projectRoot = p.join('/')
+    const out = p
+    outputPath.split('/').every(_ => {
+      var godotProjectFile = FileInfo.joinPaths(out.join('/'), 'project.godot');
+      if (!File.exists(godotProjectFile)) {
+        out.pop()
+        return true;
+      }
+      return false;
+    })
+    projectRoot = out.join('/')
   }
   projectRoot = projectRoot.replace(/\\/g, '/')
-  // Use it as absolute, if it doesn't start with ".", relative if it does
+
+  // Use projectRoot as absolute if it doesn't start with ".", relative if it does
   if (projectRoot[0] === '.') {
     const out = p
-    projectRoot.split('/').forEach((segment, i) => {
+    projectRoot.split('/').forEach((segment) => {
       if (segment === '..') {
         out.pop()
       }
     })
     projectRoot = out.join('/')
   }
+
   return projectRoot
 }
 


### PR DESCRIPTION
I updated Tiled and this plugin to the latest versions and found that my pre-existing TileMaps and TileSets no longer exported successfully. After some digging through the code and PR history, I found that this PR broke backwards compatibility with the `projectRoot` custom property:
https://github.com/mapeditor/tiled-to-godot-export/pull/40

The original intent of `projectRoot` was to define the Godot project root (the location of  the `project.godot` file), which is defined in Godot as `res://`:
https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html

All resource paths are relative to the `projectRoot` and the exporter created them automatically if `projectRoot` was properly set. The above PR changed the meaning of `projectRoot` to directly define the relative path to a resource. **I think if this functionality is still desired, it should be introduced as another optional custom property, something like `resPath` maybe.**

**In order to maintain backwards compatibility, I reverted the change to `projectRoot`.** Any projects using the existing tagged release can now upgrade without breaking. As a bonus, **I added code to automatically determine the project root, so long as the Tiled files are stored alongside their exports within the Godot project structure as is recommended.** I think this will reduce the headache new users have when trying to adopt this plugin. I know `projectRoot` was the most confusing thing to me when I first attempted an export.

I think the referenced issues the PR was trying to address may have stemmed around a lack of documentation regarding the `projectRoot` custom property. I've tried to update the readme to be a bit more clear about what `projectRoot` does. 

I don't want to diminish the effort put into https://github.com/mapeditor/tiled-to-godot-export/pull/40. I really like the naming changes. I think if the different res path functionality is still desired, we can absolutely add it in another PR with a different custom property (or I could even add it to this one). 