### PR TITLE
Use ES modules

### DIFF
--- a/export_to_godot_tilemap.mjs
+++ b/export_to_godot_tilemap.mjs
@@ -1,6 +1,15 @@
 /*global tiled, TextFile */
+
+import { stringifyKeyValue, getResPath, stringifyNode, splitCommaSeparated, getTilesetColumns } from './utils';
+
 class GodotTilemapExporter {
 
+    /**
+     * Constructs a new instance of the tilemap exporter
+     *
+     * @param {TileMap} map - The tilemap to export
+     * @param {string} fileName - The path where the user has chosen to export the tilemap
+     */
     // noinspection DuplicatedCode
     constructor(map, fileName) {
         this.map = map;
@@ -15,6 +24,7 @@ class GodotTilemapExporter {
         /**
          * Tiled doesn't have tileset ID so we create a map
          * Tileset name to generated tilesetId.
+         * @type {Map<string, number>}
          */
         this.tilesetsIndex = new Map();
 
@@ -40,7 +50,7 @@ class GodotTilemapExporter {
      *
      * @param {string} type the type of subresource
      * @param {object} contentProperties key:value map of properties
-     * @returns {int} the created sub resource id
+     * @returns {number} the created sub resource id
      */
     addSubResource(type, contentProperties) {
         const id = this.subResourceId++;
@@ -64,10 +74,8 @@ class GodotTilemapExporter {
      * Godot supports several image textures per tileset but Tiled Editor doesn't.
      * Tiled editor supports only one tile
      * sprite image per tileset.
-     * @returns {string}
      */
     setTilesetsString() {
-
         // noinspection JSUnresolvedVariable
         for (let index = 0; index < this.map.tilesets.length; ++index) {
             // noinspection JSUnresolvedVariable
@@ -78,7 +86,6 @@ class GodotTilemapExporter {
             let tilesetPath = getResPath(this.map.property("projectRoot"), this.map.property("relativePath"), tileset.asset.fileName.replace('.tsx', '.tres'));
             this.tilesetsString += this.getTilesetResourceTemplate(this.extResourceId, tilesetPath, "TileSet");
         }
-
     }
 
     /**
@@ -96,6 +103,12 @@ class GodotTilemapExporter {
         }
     }
 
+    /**
+     * Export a layer in the tilemap
+     * @param {TileLayer} layer - The layer to export
+     * @param {number} mode - The layer mode/orientation. Currently only 1 (Isometric) is supported.
+     * @param {string} layer_parent - The path of the parent layer
+     */
     handleLayer(layer, mode, layer_parent) {
         // noinspection JSUnresolvedVariable
         if (layer.isTileLayer) {
@@ -110,6 +123,7 @@ class GodotTilemapExporter {
                     this.tileMapsString += this.getTileMapTemplate(tileMapName, mode, ld.tilesetID, ld.poolIntArrayString, layer, layer_parent);
                 }
             }
+
         } else if (layer.isObjectLayer) {
             // create layer
             this.tileMapsString += stringifyNode({
@@ -278,6 +292,7 @@ class GodotTilemapExporter {
      * It's important to not use more than one tileset for a layer.
      * Otherwise the tiles from the second layer are going to be displayed incorrectly as tiles form the first
      * or with a wrong index leading to crash on export.
+     * @param {TileLayer} layer - The target layer
      * @returns {{tilesetID: *, poolIntArrayString: string, layerName: *}}
      */
     getLayerData(layer) {
@@ -368,6 +383,11 @@ class GodotTilemapExporter {
         return tilesetList;
     }
 
+    /**
+     * Finds the id of a tileset
+     * @param {Tileset} tileset - The tileset for which to find the id
+     * @returns {number} - The id of the tileset
+     */
     getTilesetIDByTileset(tileset) {
         return this.tilesetsIndex.get(tileset.name);
     }

--- a/export_to_godot_tilemap.mjs
+++ b/export_to_godot_tilemap.mjs
@@ -1,6 +1,6 @@
 /*global tiled, TextFile */
 
-import { stringifyKeyValue, getResPath, stringifyNode, splitCommaSeparated, getTilesetColumns } from './utils';
+import { stringifyKeyValue, getResPath, stringifyNode, splitCommaSeparated, getTilesetColumns } from './utils.mjs';
 
 class GodotTilemapExporter {
 

--- a/export_to_godot_tileset.mjs
+++ b/export_to_godot_tileset.mjs
@@ -1,6 +1,6 @@
 /*global tiled, TextFile */
 
-import { getResPath, getTilesetColumns } from './utils';
+import { getResPath, getTilesetColumns } from './utils.mjs';
 
 class GodotTilesetExporter {
 

--- a/export_to_godot_tileset.mjs
+++ b/export_to_godot_tileset.mjs
@@ -1,4 +1,7 @@
 /*global tiled, TextFile */
+
+import { getResPath, getTilesetColumns } from './utils';
+
 class GodotTilesetExporter {
 
     // noinspection DuplicatedCode

--- a/utils.mjs
+++ b/utils.mjs
@@ -152,8 +152,10 @@ export function stringifyNode(nodeProperties, contentProperties = {}, metaProper
  *
  * @param {string} key
  * @param {string|array} value
- * @param {bool} quote
- * @param {bool} spaces
+ * @param {boolean} quoteKey
+ * @param {boolean} quoteValue
+ * @param {boolean} spaces
+ * @param {string} separator
  */
 export function stringifyKeyValue(key, value, quoteKey, quoteValue, spaces, separator = "=") {
   // flatten arrays

--- a/utils.mjs
+++ b/utils.mjs
@@ -119,16 +119,16 @@ export function stringifyNode(nodeProperties, contentProperties = {}, metaProper
   str += '[node';
   for (const [key, value] of Object.entries(nodeProperties)) {
     if (value !== undefined) {
-      str += ' ' + this.stringifyKeyValue(key, value, false, true, false);
+      str += ' ' + stringifyKeyValue(key, value, false, true, false);
     }
   }
   str += ']\n';
   for (const [key, value] of Object.entries(contentProperties)) {
     if (value !== undefined) {
-      str += this.stringifyKeyValue(key, value, false, false, true) + '\n';
+      str += stringifyKeyValue(key, value, false, false, true) + '\n';
     }
   }
-  mProps = Object.entries(metaProperties)
+  const mProps = Object.entries(metaProperties)
   if(mProps.length > 0) {
     str += '__meta__ = {\n';
     var count = 0;
@@ -140,7 +140,7 @@ export function stringifyNode(nodeProperties, contentProperties = {}, metaProper
         if(typeof value === 'number' || typeof value === 'boolean') {
             quoteValue = false;
         }
-        str += this.stringifyKeyValue(key, value, true, quoteValue, true, ":");
+        str += stringifyKeyValue(key, value, true, quoteValue, true, ":");
     }
     str += '\n}\n';
   }

--- a/utils.mjs
+++ b/utils.mjs
@@ -3,10 +3,10 @@ var Flatted=function(a,l){return{parse:function(n,t){var e=JSON.parse(n,i).map(f
 
 var log = console.log.bind(console);
 
-function logf(data) {
+export function logf(data) {
   console.log(Flatted.stringify(data));
 }
-function logk(data) {
+export function logk(data) {
   console.log(Object.keys(data));
 }
 
@@ -24,7 +24,7 @@ function logk(data) {
  * @param {string} outputPath full path and name of destination file. Ex: 'C:/project/maps/level1/tileset.tres'
  * @returns {string} full relative path to file to be included in a 'res://' path. Ex: 'maps/level1/tileset.tres'
  */
-function getResPath(projectRoot, relativePath, outputPath) {
+export function getResPath(projectRoot, relativePath, outputPath) {
   let fullResPath = ''
   if (relativePath) {
     // Replace all backslashes with forward slashes
@@ -78,7 +78,7 @@ function getResPath(projectRoot, relativePath, outputPath) {
  * tile spacing (padding between individual tiles).
  * @returns {number}
  */
-function getTilesetColumns(tileset) {
+export function getTilesetColumns(tileset) {
   // noinspection JSUnresolvedVariable
   const imageWidth = tileset.imageWidth + tileset.tileSpacing - tileset.margin
   const tileWidth = tileset.tileWidth + tileset.tileSpacing
@@ -91,7 +91,7 @@ function getTilesetColumns(tileset) {
 /**
  * @param {string} str comma separated items
  */
-function splitCommaSeparated(str) {
+export function splitCommaSeparated(str) {
   if (!str) {
     return undefined;
   }
@@ -114,7 +114,7 @@ function splitCommaSeparated(str) {
             }
  *         ```
  */
-function stringifyNode(nodeProperties, contentProperties = {}, metaProperties = {}) {
+export function stringifyNode(nodeProperties, contentProperties = {}, metaProperties = {}) {
   let str = '\n';
   str += '[node';
   for (const [key, value] of Object.entries(nodeProperties)) {
@@ -155,7 +155,7 @@ function stringifyNode(nodeProperties, contentProperties = {}, metaProperties = 
  * @param {bool} quote
  * @param {bool} spaces
  */
-function stringifyKeyValue(key, value, quoteKey, quoteValue, spaces, separator = "=") {
+export function stringifyKeyValue(key, value, quoteKey, quoteValue, spaces, separator = "=") {
   // flatten arrays
   if (Array.isArray(value)) {
     value = '[\n"' + value.join('","') + '",\n]';


### PR DESCRIPTION
Attempting to implement feature #36 by renaming files to `.mjs` and using `import`/`export` as suggested.

The extension loads fine for me and exporting tilemaps and tilesets works as before.

Tested only with Tiled 1.9

