### PR TITLE
Added support for one-way collision shapes

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,9 @@ To setup a collision shape for a tile, first edit the tileset in Tiled:
 
 - Select the tile in the tileset file
 - You should see a side panel "Tile Collision Editor", use the menu above it to create a new shape. Use rectangle or polygon only.
+- For a one-way collision, with the Object shape selected set the `Type` or `Class` field to `one-way`.
 
-For navigation, do the same thing, but with the Object shape selected, set the `Type` field to `navigation`.
+For navigation, do the same thing, but with the Object shape selected, set the `Type` or `Class` field to `navigation`.
 
 ## Why use it?
 
@@ -164,7 +165,7 @@ More about my struggles can be read in Tiled Forum or Godot reddit. Check the Co
 - [x] Export collision shapes<sup>*</sup>
 - [ ] Export occluder shapes<sup>*</sup>
 - [x] Export navigation shapes<sup>*</sup>
-- [ ] Support for one-way collision shapes
+- [x] Support for one-way collision shapes
 - [ ] Support for image layers
 - [x] Support for tile objects, which are exported to Godot as Sprite nodes. (Other types of objects are not yet included.)
 - [ ] Full support for object layers, which are exported as StaticBody2D, Area2D or LightOccluder2D for shapes (depending on the type property) and as Sprite for tiles

--- a/export_to_godot_tileset.mjs
+++ b/export_to_godot_tileset.mjs
@@ -101,13 +101,14 @@ class GodotTilesetExporter {
      * @param {point} autotileCoordinates autotile coordinates for the tile
      */
     exportCollisions(object, tile, autotileCoordinates) {
+        var isOneWay = object.type === "one-way";
         // noinspection JSUnresolvedVariable
         if (object.polygon.length > 0) {
             this.shapesResources += this.getCollisionShapePolygon(tile.id, object);
-            this.exportShapes(tile, autotileCoordinates);
+            this.exportShapes(tile, autotileCoordinates, isOneWay);
         } else if (object.width > 0 && object.height > 0) {
             this.shapesResources += this.getCollisionShapeRectangle(tile.id, object);
-            this.exportShapes(tile, autotileCoordinates);
+            this.exportShapes(tile, autotileCoordinates, isOneWay);
         }
     }
 
@@ -132,13 +133,13 @@ class GodotTilesetExporter {
      * @param {Tile} tile the target tile
      * @param {point} autotileCoordinates autotile coordinates for the tile
      */
-    exportShapes(tile, autotileCoordinates) {
+    exportShapes(tile, autotileCoordinates, isOneWay) {
         if (this.firstShapeID === "") {
             this.firstShapeID = 'SubResource( ' + tile.id + ' )';
         }
         this.shapes += this.getShapesTemplate(
             autotileCoordinates,
-            false,
+            isOneWay,
             tile.id
         );
     }


### PR DESCRIPTION
**Usage**

- In Tiled, select a tile collision shape to show the properties in the left panel
- Under the property "Type" (or "Class" in Tiled 1.9) use the value "one-way"
- Export the tileset to Godot.

Other notes: The "one-way" className/type on the collision shape is the same method employed by godot-tiled-importer